### PR TITLE
fix examples

### DIFF
--- a/docs/src/pages/slider-demos/horizontal/AllowCrossing.js
+++ b/docs/src/pages/slider-demos/horizontal/AllowCrossing.js
@@ -20,7 +20,7 @@ const railStyle = {
 }
 
 const domain = [100, 500]
-const defaultValues = [450, 400, 300, 150]
+const defaultValues = [150, 300, 400, 450]
 
 class Example extends Component {
   state = {

--- a/docs/src/pages/slider-demos/horizontal/Basic.js
+++ b/docs/src/pages/slider-demos/horizontal/Basic.js
@@ -20,7 +20,7 @@ const railStyle = {
 }
 
 const domain = [100, 500]
-const defaultValues = [450, 400, 300, 150]
+const defaultValues = [150, 300, 400, 450]
 
 class Example extends Component {
   state = {

--- a/docs/src/pages/slider-demos/vertical/AllowCrossing.js
+++ b/docs/src/pages/slider-demos/vertical/AllowCrossing.js
@@ -22,7 +22,7 @@ const railStyle = {
 }
 
 const domain = [100, 500]
-const defaultValues = [450, 400, 300, 150]
+const defaultValues = [150, 300, 400, 450]
 
 class Example extends Component {
   state = {

--- a/docs/src/pages/slider-demos/vertical/Basic.js
+++ b/docs/src/pages/slider-demos/vertical/Basic.js
@@ -22,7 +22,7 @@ const railStyle = {
 }
 
 const domain = [100, 500]
-const defaultValues = [450, 400, 300, 150]
+const defaultValues = [150, 300, 400, 450]
 
 class Example extends Component {
   state = {


### PR DESCRIPTION
Hi and props for this project, I love it!

Just a small fix for these examples. In these 4 examples the order of the values is reversed, so the initial values that are displayed in the `Viewer` are:

```
onChange: 450 400 300 150
onUpdate: 450 400 300 150
```

Now, lets say that I drag the farthest-right handle to `500`, then what I see in the viewer is:

```
onChange: 450 400 300 150
onUpdate: 150 300 400 500
```

Which is a bit confusing.
  