### PR TITLE
[FIX] Wrong onUpdate/onChange call

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -65,8 +65,10 @@ class Slider extends PureComponent {
     ) {
       this.updateRange(domain, step, reversed)
       const remapped = this.reMapValues(reversed)
-      next.onChange(remapped)
-      next.onUpdate(remapped)
+      if (values === undefined || values === props.values) {
+        next.onChange(remapped)
+        next.onUpdate(remapped)
+      }
     }
 
     if (!equal(values, props.values)) {

--- a/src/Slider/Slider.spec.js
+++ b/src/Slider/Slider.spec.js
@@ -105,6 +105,50 @@ describe('<Slider />', () => {
     updateValuesSpy.restore()
   })
 
+  it('does call onChange/onUpdate when it should', () => {
+    const onUpdate = sinon.spy()
+    const onChange = sinon.spy()
+
+    const props = {
+      onChange,
+      onUpdate,
+      reversed: false,
+      step: 10,
+      domain: [100, 200],
+      values: [100, 200],
+    }
+
+    const wrapper = shallow(<Slider {...props} />)
+
+    assert.strictEqual(onUpdate.callCount, 0)
+    assert.strictEqual(onChange.callCount, 0)
+    wrapper.setProps({ ...props, domain: [50, 200] })
+    assert.strictEqual(onUpdate.callCount, 1)
+    assert.strictEqual(onChange.callCount, 1)
+  })
+
+  it("does NOT call onChange/onUpdate when it shouldn't", () => {
+    const onUpdate = sinon.spy()
+    const onChange = sinon.spy()
+
+    const props = {
+      onChange,
+      onUpdate,
+      reversed: false,
+      step: 10,
+      domain: [100, 200],
+      values: [100, 200],
+    }
+
+    const wrapper = shallow(<Slider {...props} />)
+
+    assert.strictEqual(onUpdate.callCount, 0)
+    assert.strictEqual(onChange.callCount, 0)
+    wrapper.setProps({ ...props, domain: [50, 200], values: [50, 200] })
+    assert.strictEqual(onUpdate.callCount, 0)
+    assert.strictEqual(onChange.callCount, 0)
+  })
+
   it('does NOT call updateRange when reversed, domain and step are unchanged', () => {
     const wrapper = shallow(
       <Slider reversed={false} step={10} domain={[100, 200]} />,


### PR DESCRIPTION
Hi,

I've detected a pretty annoying bug (at least for me).

I understand that `onChange` and `onUpdate` should be invoked when the `domain` changes if the `values` property hasn't been updated too... I mean, if it's an "uncontrolled" instance (`values` is not being used) then those functions should always be invoked. If it's controlled, on the other hand, I think that they should only be invoked if the `values` property hasn't changed (shallow compare).

For instance: If my instance had the domain `[0, 100]` and the values: `[70]` and I update the domain to `[0, 300]` and the value to `[10]`, I don't want those functions to be reinvoked, because if they do, they will send me the wrong value (that I'm trying to override) and I won't be able to know if that update was triggered by the user or lifecycle of the component.

I know that I could get around this by updating the `key` prop of my instance every time that I change the domain... But that's a bit annoying.

Once again: thanks for this amazing library!