### PR TITLE
fix(Slider): incorrect vertical value for getSliderDomain

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -168,7 +168,8 @@ class Slider extends PureComponent {
   }
 
   componentDidMount() {
-    const { vertical, pixelToStep } = this.state
+    const { pixelToStep } = this.state
+    const { vertical } = this.props
 
     pixelToStep.setDomain(
       getSliderDomain(this.slider.current, vertical, pixelToStep),


### PR DESCRIPTION
Slider.componentDidMount incorrectly takes vertical from state instead
of props, which causes the dimensions to be incorrect for vertical
sliders until the rail has been clicked

This fixes #57 