### PR TITLE
Add type definitions for new Slider props

### DIFF
--- a/src/Slider/Slider.d.ts
+++ b/src/Slider/Slider.d.ts
@@ -26,8 +26,10 @@ export interface SliderProps {
   onSlideStart?: (values: ReadonlyArray<number>) => void;
   onSlideEnd?: (values: ReadonlyArray<number>) => void;
   className?: string;
+  component?: string;
   rootStyle?: React.CSSProperties;
   children: React.ReactNode;
+  flatten?: boolean;
 }
 
 declare const Slider: React.ComponentType<SliderProps>;


### PR DESCRIPTION
Here are type definitions for the new `Slider` props, just to make sure they don't fall through the cracks!