### PR TITLE
Add check for isMounted before performing setState in Slider

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "build/dist/react-compound-slider.js": {
-    "bundled": 78588,
-    "minified": 27647,
-    "gzipped": 8655
+    "bundled": 78791,
+    "minified": 27743,
+    "gzipped": 8683
   },
   "build/dist/react-compound-slider.min.js": {
-    "bundled": 12370,
-    "minified": 12348,
-    "gzipped": 4262
+    "bundled": 12466,
+    "minified": 12444,
+    "gzipped": 4289
   }
 }

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -51,6 +51,7 @@ class Slider extends PureComponent {
     pixelToStep: null,
   }
 
+  _isMounted = false
   slider = React.createRef()
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -151,6 +152,7 @@ class Slider extends PureComponent {
   }
 
   componentDidMount() {
+    this._isMounted = true
     const { pixelToStep } = this.state
     const { vertical } = this.props
 
@@ -159,6 +161,7 @@ class Slider extends PureComponent {
 
   componentWillUnmount() {
     this.removeListeners()
+    this._isMounted = false
   }
 
   removeListeners() {
@@ -428,7 +431,9 @@ class Slider extends PureComponent {
     onChange(handles.map(d => d.val))
     onSlideEnd(handles.map(d => d.val), { activeHandleID })
 
-    this.setState({ activeHandleID: null })
+    if (this._isMounted) {
+      this.setState({ activeHandleID: null })
+    }
 
     if (isBrowser) {
       document.removeEventListener('mousemove', this.onMouseMove)
@@ -445,7 +450,9 @@ class Slider extends PureComponent {
     onChange(handles.map(d => d.val))
     onSlideEnd(handles.map(d => d.val), { activeHandleID })
 
-    this.setState({ activeHandleID: null })
+    if (this._isMounted) {
+      this.setState({ activeHandleID: null })
+    }
 
     if (isBrowser) {
       document.removeEventListener('touchmove', this.onTouchMove)


### PR DESCRIPTION
I was experiencing this error when using the `Slider` component:

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
```

This was caused by my component re-rendering before the `Slider` was finished setting state for `activeHandleID`. All other updates were applied that I would expect (i.e. the UI was updated, onUpdate and onChange ran as expected, etc.).To resolve this, I ensure that the component is still mounted before calling that `setState`.