### PR TITLE
Fix `null` issue while rendering on server (Wordpress)

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -43,7 +43,7 @@ class Slider extends PureComponent {
     step: null,
     values: null,
     domain: null,
-    handles: null,
+    handles: [],
     reversed: null,
     activeHandleID: null,
     valueToPerc: null,


### PR DESCRIPTION
## Overview

When using this package and rendering it on a server (Wordpress), I receive this error at https://github.com/sghall/react-compound-slider/blob/master/src/Slider/Slider.js#L475:

```
TypeError: Cannot read property 'map' of null
```

This PR fixes the issue by changing the default value for `handles` to an empty array (`[]`)