### PR TITLE
Export TracksProps interface

### DIFF
--- a/src/Tracks/index.d.ts
+++ b/src/Tracks/index.d.ts
@@ -1,1 +1,1 @@
-export { default, TrackItem, TracksObject, GetTrackProps } from './Tracks';
+export { default, TrackItem, TracksObject, GetTrackProps, TracksProps } from './Tracks';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,7 +13,7 @@ export interface EventData {
 
 export type GetEventData = (e: React.SyntheticEvent | Event) => EventData; 
 
-export { default as Tracks, TrackItem, TracksObject, GetTrackProps } from './Tracks';
+export { default as Tracks, TrackItem, TracksObject, GetTrackProps, TracksProps } from './Tracks';
 export { default as Ticks, TicksObject, TicksProps } from './Ticks';
 export { default as Slider, SliderProps, SliderModeValue, SliderModeFunction } from './Slider';
 export { default as Rail, GetRailProps, RailProps, RailObject } from './Rail';


### PR DESCRIPTION
Resolve this issue: https://github.com/sghall/react-compound-slider/issues/100

Add missing exports to package.