### PR TITLE
Update types.ts GetEventData to match Slider.tsx

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type EmitKeyboard = (e: KeyboardEvent<Element>, id?: string) => void;
 export type EmitMouse = (e: MouseEvent<Element>, id?: string) => void;
 export type EmitTouch = (e: TouchEvent<Element>, id?: string) => void;
 
-export type GetEventData = (e: React.SyntheticEvent | Event) => EventData;
+export type GetEventData = (e: React.SyntheticEvent | Event, isTouch?: boolean) => EventData;
 
 export type OtherProps = { [key: string]: any };
 


### PR DESCRIPTION
Hi there `react-compound-slider` devs.  Just a small update request to your types file so that it doesn't need to be overwritten if people want access to `isTouch`.

Implementation of `GetEventData` in Slider.tsx contains a boolean which is not present in the types.ts file.  Relevant snippet here: https://github.com/sghall/react-compound-slider/blob/2fff320a8476d4f2b03cd6cfb83e79e916b5592e/src/Slider/Slider.tsx#L352

I've left `isTouch` as optional so that it does not break existing functionality.